### PR TITLE
CheckDateClose. Run Multi Ext

### DIFF
--- a/db/get.go
+++ b/db/get.go
@@ -5,18 +5,18 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-func Get(db sqlx.Queryer, dest interface{}, qry squirrel.SelectBuilder) error {
+func Get(db sqlx.Queryer, val interface{}, qry squirrel.SelectBuilder) error {
 	sql, args, err := qry.ToSql()
 	if err != nil {
 		return err
 	}
-	return sqlx.Get(db, dest, sql, args...)
+	return sqlx.Get(db, val, sql, args...)
 }
 
-func Select(db sqlx.Queryer, dest interface{}, qry squirrel.SelectBuilder) error {
+func Select(db sqlx.Queryer, slice interface{}, qry squirrel.SelectBuilder) error {
 	sql, args, err := qry.ToSql()
 	if err != nil {
 		return err
 	}
-	return sqlx.Select(db, dest, sql, args...)
+	return sqlx.Select(db, slice, sql, args...)
 }

--- a/db/tx.go
+++ b/db/tx.go
@@ -3,6 +3,7 @@ package dbUtil
 import "github.com/jmoiron/sqlx"
 
 type TxFunc func(tx *sqlx.Tx) error
+type ExtFunc func(tx sqlx.Ext) error
 
 func TxNow(db *sqlx.DB, fn TxFunc) error {
 	tx, err := db.Beginx()
@@ -35,6 +36,15 @@ func QuickExecTx(tx sqlx.Execer, queries []string, arg ...interface{}) error {
 func RunMulti(tx *sqlx.Tx, fns []TxFunc) error {
 	for _, f := range fns {
 		if err := f(tx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func RunMultiExt(ext sqlx.Ext, fns []ExtFunc) error {
+	for _, f := range fns {
+		if err := f(ext); err != nil {
 			return err
 		}
 	}

--- a/time/time.go
+++ b/time/time.go
@@ -1,10 +1,33 @@
 package timeUtils
 
-import "time"
+import (
+	"errors"
+	"fmt"
+	"time"
+)
 
 // Sometimes, NULL presents as a non-zero time.
 // Consequently, checking IsZero is not enough.
 func IsReasonableTime(t time.Time) bool {
 	comp, _ := time.Parse(time.RFC3339, "1900-00-00T00:00:00Z")
 	return t.After(comp)
+}
+
+func ParseTimeCheckNear(date, format string, target time.Time, leeway time.Duration) (bool, error) {
+	found, err := time.Parse(format, date)
+	if err != nil {
+		return false, fmt.Errorf("error formatting %s to format %s, err %s", date, format, err)
+	}
+
+	if TimeNearTime(found, target, leeway) {
+		return true, nil
+	}
+
+	return false, errors.New(fmt.Sprintf("expected date %s +/- %s but got %s which is off by %f seconds", target, leeway, found, target.Sub(found).Seconds()))
+}
+
+func TimeNearTime(date time.Time, target time.Time, leeway time.Duration) bool {
+	above := target.Add(leeway * -1)
+	below := target.Add(leeway)
+	return date.Before(below) && date.After(above)
 }


### PR DESCRIPTION
CheckDateClose I use in tests of dates returning from a route as JSON
```
			Ranges: &expected_m.ExpectedM{
				"0.finish": expected_m.CheckDateClose(time.Date(2099, 1, 01, 0, 0, 0, 0, london), time.Second),
				"0.start":  expected_m.CheckDateClose(time.Date(2012, 8, 1, 13, 53, 51, 0, van), time.Second),
				"#":        36,
			}
```

destVar and destSlice were because I could never remember whether I wanted Select or Get.

The Ext is nice to have for functions which take Tx or Db.