### PR TITLE
feature: S3 wrapper with resumable upload support

### DIFF
--- a/s3/errors.go
+++ b/s3/errors.go
@@ -1,0 +1,23 @@
+package s3util
+
+import "errors"
+
+var (
+	ErrUploadNotFound             = errors.New("upload not found")
+	ErrResumedUploadOffsetInvalid = errors.New("offset does not match uploaded status")
+	ErrTimeout                    = errors.New("timeout")
+)
+
+type InitError struct {
+	error error
+}
+func (e InitError) Error() string {
+	return "upload initialization error: " + e.error.Error()
+}
+
+type UploadError struct {
+	error error
+}
+func (e UploadError) Error() string {
+	return "upload part error: " + e.error.Error()
+}

--- a/s3/main.go
+++ b/s3/main.go
@@ -19,6 +19,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+// DEPRECATED: this file is deprecated. We should migrate to the newer S3 interface.
+
 const (
 	TempDirectoryEnv = "TEMP_DIR" // Would just use default temp directory if not specified
 )
@@ -29,16 +31,16 @@ type S3Info interface {
 	DefaultBucket() string
 	// Allows prefixing, suffixing around keys based on hash sums
 	MkHashKey(string) string
-	// Creates an S3 URL that utilizes the DefaultBucket
+	// Creates an Service URL that utilizes the DefaultBucket
 	MkURL(string) string
 }
 
-// Wrapper around S3 Downloader for stubbing
+// Wrapper around Service Downloader for stubbing
 type Downloader interface {
 	Download(w io.WriterAt, i *s3.GetObjectInput, options ...func(*s3manager.Downloader)) (int64, error)
 }
 
-// Wrapper around S3 Uploader for stubbing
+// Wrapper around Service Uploader for stubbing
 type Uploader interface {
 	Upload(input *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
 }
@@ -149,7 +151,7 @@ func ObjectExistsS3(info S3Info, key string) (*s3.HeadObjectOutput, bool, error)
 	sess := s3.New(info.GetSession())
 	obj, err := sess.HeadObject(&s3.HeadObjectInput{
 		Bucket: aws.String(info.DefaultBucket()),
-		Key:    aws.String(key),
+		Key:    aws.String(info.MkHashKey(key)),
 	})
 
 	if err == nil {
@@ -203,7 +205,7 @@ func DownloadS3(downloader Downloader, bucket, key string) (*os.File, error) {
 		return nil, errors.Wrapf(err, "Unable to create temp file while downloading s3 file %v:%v", bucket, key)
 	}
 
-	// Write the contents of S3 Object to the file
+	// Write the contents of Service Object to the file
 	_, err = downloader.Download(file, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),

--- a/s3/service.go
+++ b/s3/service.go
@@ -1,0 +1,258 @@
+package s3util
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+const DefaultChunkSizeLimit = 1024 * 1024 * 50
+const DefaultIncompleteExpiry = time.Hour * 24
+
+type Service struct {
+	Bucket      string
+	Region      string
+	Timeout     time.Duration
+	Concurrency int // Concurrent downloading
+
+	ChunkSizeLimit         int
+	MinUploadSizeChunked   int
+	IncompleteUploadExpiry time.Duration
+
+	incomplete map[string]*Upload
+	lock       sync.RWMutex
+
+	Session *session.Session
+	Client  *s3.S3
+
+	uploads  chan *Upload
+	shutdown chan bool
+}
+
+func (s *Service) Init(id, secret string) error {
+	sess, err := session.NewSession(&aws.Config{
+		Credentials: credentials.NewStaticCredentials(id, secret, ""),
+		Region:      aws.String(s.Region),
+	})
+	if err != nil {
+		return err
+	}
+
+	if s.ChunkSizeLimit == 0 {
+		s.ChunkSizeLimit = DefaultChunkSizeLimit
+	}
+	if s.MinUploadSizeChunked == 0 {
+		s.MinUploadSizeChunked = DefaultChunkSizeLimit
+	}
+	if s.IncompleteUploadExpiry == 0 {
+		s.IncompleteUploadExpiry = DefaultIncompleteExpiry
+	}
+
+	s.Client = s3.New(sess)
+	s.Session = sess
+	s.uploads = make(chan *Upload, 10)
+	s.shutdown = make(chan bool)
+	s.incomplete = make(map[string]*Upload)
+	return nil
+}
+
+// Checks if the file exists
+func (s *Service) Exists(filepath string) (bool, error) {
+	_, err := s.Client.HeadObject(&s3.HeadObjectInput{
+		Bucket: aws.String(s.Bucket),
+		Key:    aws.String(filepath),
+	})
+	if err == nil {
+		return true, nil
+	}
+
+	aerr, ok := err.(awserr.Error)
+	if !ok || aerr.Code() != "NotFound" {
+		return false, err
+	}
+	return false, nil
+}
+
+// Gets a file reader from Service
+func (s *Service) Get(filepath string) (io.ReadCloser, error) {
+	out, err := s.Client.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(s.Bucket),
+		Key:    aws.String(filepath),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out.Body, nil
+}
+
+func (s *Service) Download(filepath string, w io.WriterAt) error {
+	dlr := s3manager.NewDownloader(s.Session)
+	dlr.Concurrency = s.Concurrency
+	_, err := dlr.Download(w, &s3.GetObjectInput{
+		Bucket: aws.String(s.Bucket),
+		Key:    aws.String(filepath),
+	})
+	return err
+}
+
+func (s *Service) DownloadRange(filepath string, w io.WriterAt, start, finish int) error {
+	dlr := s3manager.NewDownloader(s.Session)
+	dlr.Concurrency = s.Concurrency
+	_, err := dlr.Download(w, &s3.GetObjectInput{
+		Bucket: aws.String(s.Bucket),
+		Key:    aws.String(filepath),
+		Range:  aws.String(fmt.Sprintf("bytes=%d-%d", start, finish)),
+	})
+	return err
+}
+
+// Put here is generally only used if you do not care about progress or status updates as it hides
+// this information from the user. You only get the final error or non-error code.
+func (s *Service) Put(filepath string, filesize int, r io.Reader) error {
+	ch := s.PutWithStatus(filepath, filesize, r)
+	for {
+		select {
+		case <-time.After(s.Timeout):
+			return ErrTimeout
+		case status := <-ch:
+			switch status.Code {
+			case UploadStatusCodeOk:
+				return nil
+			case UploadStatusCodeError:
+				return status.Error
+			}
+		}
+	}
+}
+
+// Tries to put the file in Service. Use the returned channel to retrieve messages from the
+// upload. With small uploads, the only statuses returned should be Ok and Error.
+func (s *Service) PutWithStatus(filepath string, filesize int, r io.Reader) chan UploadStatus {
+	if filesize <= s.MinUploadSizeChunked {
+		return s.putSimply(filepath, r)
+	}
+
+	// Here, we need to put the file in a more complicated manner!
+	// in this case, there might be more details to send back to the Client.
+	chunks := int(math.Ceil(float64(filesize) / float64(s.ChunkSizeLimit)))
+
+	upload := &Upload{
+		Filepath:       filepath,
+		FileSize:       filesize,
+		R:              r,
+		s:              s,
+		Expiry:         time.Now().Add(s.IncompleteUploadExpiry),
+		notifier:       make(chan UploadStatus),
+		parts:          make(chan []byte, chunks),
+		completedParts: make([]*s3.CompletedPart, 0, chunks),
+	}
+	s.uploads <- upload
+	go upload.Send()
+
+	return upload.notifier
+}
+
+// Resumes an incomplete upload.
+func (s *Service) ResumePutWithStatus(filepath string, offset int, r io.Reader) (chan UploadStatus, error) {
+	upload := s.GetIncompleteUpload(filepath)
+	if upload == nil {
+		return nil, ErrUploadNotFound
+	}
+	if upload.Uploaded != offset {
+		return nil, ErrResumedUploadOffsetInvalid
+	}
+
+	// Take this upload and put it back on the channel, but with a new reader.
+	s.removeFromIncomplete(filepath)
+	upload.R = r
+	upload.Expiry = time.Now().Add(s.IncompleteUploadExpiry)
+	s.uploads <- upload
+	go upload.Send()
+
+	return upload.notifier, nil
+}
+
+// Deletes the file from S3
+func (s *Service) Delete(filepath string) error {
+	_, err := s.Client.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(s.Bucket),
+		Key:    aws.String(filepath),
+	})
+	return err
+}
+
+// Retrieves the incomplete upload, it if exists.
+func (s *Service) GetIncompleteUpload(filepath string) *Upload {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.incomplete[filepath]
+}
+
+func (s *Service) removeFromIncomplete(filepath string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	delete(s.incomplete, filepath)
+}
+
+func (s *Service) registerIncompleteUpload(upload *Upload) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.incomplete[ upload.Filepath ] = upload
+}
+
+func (s *Service) putSimply(filepath string, r io.Reader) chan UploadStatus {
+	upl := s3manager.NewUploader(s.Session)
+	_, err := upl.Upload(&s3manager.UploadInput{
+		Bucket: aws.String(s.Bucket),
+		Key:    aws.String(filepath),
+		Body:   r,
+	})
+
+	ch := make(chan UploadStatus, 1)
+	if err != nil {
+		ch <- errStatus(err)
+	}
+	ch <- okStatus()
+	return ch
+}
+
+// This runner uploads larger files to S3. This should be run as its own service
+// on the main function.
+func (s *Service) RunUploader() {
+	for {
+		select {
+		case <-s.shutdown:
+			return
+		case <- time.After(time.Hour):
+			s.lock.Lock()
+			for id, u := range s.incomplete {
+				if u.Expiry.After(time.Now()) {
+					delete(s.incomplete, id)
+				}
+			}
+			s.lock.Unlock()
+		case upload := <-s.uploads:
+			go func() {
+				if err := upload.Run(); err != nil {
+					s.registerIncompleteUpload(upload)
+					upload.notifier <- errStatus(err)
+				}
+			}()
+		}
+	}
+}
+
+func (s *Service) Shutdown() {
+	// Only the main process needs to shutdown. The other goroutines should
+	// shutdown on their own as they are fitted with exit on timeout.
+	s.shutdown <- true
+}

--- a/s3/service_test.go
+++ b/s3/service_test.go
@@ -1,0 +1,253 @@
+package s3util
+
+import (
+	"io/ioutil"
+	"math"
+	"os"
+	"testing"
+	"time"
+)
+
+var (
+	AwsId  = os.Getenv("AWS_ACCESS_KEY_ID")
+	AwsKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+	Bucket = os.Getenv("S3_BUCKET")
+	Region = os.Getenv("AWS_REGION")
+
+	service = &Service{
+		Bucket:      Bucket,
+		Region:      Region,
+		Timeout:     15 * time.Second,
+		Concurrency: 1,
+
+		ChunkSizeLimit:         DefaultChunkSizeLimit,
+		MinUploadSizeChunked:   DefaultChunkSizeLimit,
+		IncompleteUploadExpiry: time.Hour * 24,
+	}
+)
+
+const (
+	TestFilename1 = "test-file-1.txt"
+	TestFilesize1 = 1024 * 1024
+	TestFilename2 = "test-file-2.txt"
+	TestFilesize2 = 1024 * 1024 * 160
+)
+
+func makeFakeFile(filename string, numBytes int) {
+	f, err := os.Create("./" + filename)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	bytes := make([]byte, 0, numBytes)
+	for i := 0; i < numBytes; i++ {
+		bytes = append(bytes, byte(i))
+	}
+	if _, err := f.Write(bytes); err != nil {
+		panic(err)
+	}
+}
+
+func cleanupFile(file string) {
+	os.Remove("./" + file)
+}
+
+func initService() {
+	if err := service.Init(AwsId, AwsKey); err != nil {
+		panic(err)
+	}
+	go service.RunUploader()
+}
+
+func TestStandardS3Services(t *testing.T) {
+	initService()
+	defer service.Shutdown()
+
+	makeFakeFile(TestFilename1, TestFilesize1)
+	defer cleanupFile(TestFilename1)
+
+	// Upload the small file to S3
+	f, err := os.Open("./" + TestFilename1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	if err := service.Put(TestFilename1, TestFilesize1, f); err != nil {
+		t.Fatal(err)
+	}
+	exists, err := service.Exists(TestFilename1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("File should be put, therefore, should exist")
+	}
+
+	// Download the file from S3
+	rf, err := service.Get(TestFilename1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fileBytes, err := ioutil.ReadAll(rf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fileBytes) != TestFilesize1 {
+		t.Fatal("File sizes not the same")
+	}
+
+	// Delete the file from S3
+	if err := service.Delete(TestFilename1); err != nil {
+		t.Fatal(err)
+	}
+	exists, err = service.Exists(TestFilename1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("File should be deleted, therefore, should not exist")
+	}
+
+	for i, b := range fileBytes {
+		if b != byte(i) {
+			t.Fatalf("Character is not the same. %d on AWS vs %d on filesystem", b, byte(i))
+		}
+	}
+}
+
+func TestChunkedUpload(t *testing.T) {
+	initService()
+	defer service.Shutdown()
+
+	// File size is large! This is because we need to test the chunked file uploader.
+	makeFakeFile(TestFilename2, TestFilesize2)
+	defer cleanupFile(TestFilename2)
+
+	f, err := os.Open("./" + TestFilename2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	notifier := service.PutWithStatus(TestFilename2, TestFilesize2, f)
+
+	numProgress := 0
+L:
+	for {
+		select {
+		case <-time.After(time.Minute * 5):
+			t.Fatal("timeout")
+		case status := <-notifier:
+			switch status.Code {
+			case UploadStatusCodeOk:
+				break L
+			case UploadStatusCodeError:
+				t.Fatal(status.Error)
+				return
+			case UploadStatusCodeProgress:
+				numProgress++
+			}
+		}
+	}
+
+	if numProgress != int(math.Ceil(float64(TestFilesize2)/float64(DefaultChunkSizeLimit))) {
+		t.Fatal("Expected number of chunks not equal")
+	}
+
+	// Retrieve the file and check it!
+	rf, err := service.Get(TestFilename2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fileBytes, err := ioutil.ReadAll(rf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fileBytes) != TestFilesize2 {
+		t.Error("Files are not the same ")
+	}
+
+	for i, b := range fileBytes {
+		if b != byte(i) {
+			t.Fatalf("Character is not the same. %d on AWS vs %d on filesystem", b, byte(i))
+		}
+	}
+
+}
+
+func TestResumeChunkUpload(t *testing.T) {
+	initService()
+	defer service.Shutdown()
+
+	// File size is large! This is because we need to test the chunked file uploader.
+	makeFakeFile(TestFilename2, TestFilesize2/2)
+	defer cleanupFile(TestFilename2)
+
+	f, err := os.Open("./" + TestFilename2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	notifier := service.PutWithStatus(TestFilename2, TestFilesize2, f)
+
+L:
+	for {
+		select {
+		case <-time.After(time.Minute * 5):
+			t.Fatal("timeout")
+		case status := <-notifier:
+			switch status.Code {
+			case UploadStatusCodeOk:
+				t.Fatal("Expecting a timeout error!")
+			case UploadStatusCodeError:
+				break L
+			}
+		}
+	}
+
+	// We need to now resume the upload!
+	f.Seek(0,0)
+	notifier, err = service.ResumePutWithStatus(TestFilename2, TestFilesize2/2, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+L2:
+	for {
+		select {
+		case <-time.After(time.Minute * 5):
+			t.Fatal("timeout")
+		case status := <-notifier:
+			switch status.Code {
+			case UploadStatusCodeOk:
+				// We should be good!
+				break L2
+			case UploadStatusCodeError:
+				t.Fatal(status.Error)
+				return
+			}
+		}
+	}
+
+	// Retrieve the file and check it!
+	rf, err := service.Get(TestFilename2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fileBytes, err := ioutil.ReadAll(rf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fileBytes) != TestFilesize2 {
+		t.Error("Files are not the same ")
+	}
+	for i, b := range fileBytes {
+		if b != byte(i) {
+			t.Fatalf("Character is not the same. %d on AWS vs %d on filesystem", b, byte(i))
+		}
+	}
+}

--- a/s3/upload.go
+++ b/s3/upload.go
@@ -1,0 +1,168 @@
+package s3util
+
+import (
+	"bytes"
+	"io"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+type UploadStatusCode string
+
+var (
+	UploadStatusCodeOk       UploadStatusCode = "Ok"
+	UploadStatusCodeProgress UploadStatusCode = "Progress"
+	UploadStatusCodeError    UploadStatusCode = "Error"
+)
+
+type UploadStatus struct {
+	Code    UploadStatusCode
+	Message string
+	Error   error
+}
+
+func okStatus() UploadStatus {
+	return UploadStatus{
+		Code: UploadStatusCodeOk,
+	}
+}
+func errStatus(err error) UploadStatus {
+	return UploadStatus{
+		Code:  UploadStatusCodeError,
+		Error: err,
+	}
+}
+
+// This is a file upload!
+type Upload struct {
+	Filepath string
+	FileSize int
+	Uploaded int
+	R        io.Reader
+
+	// Expiry refers to the time when the upload will cease to exist from
+	// the incomplete uploads list. Any expired partial file will be removed from
+	// S3 as well as from memory.
+	Expiry time.Time
+
+	s        *Service
+	notifier chan UploadStatus
+	parts    chan []byte
+
+	// Information required for S3 uploading
+	uploadId       *string
+	completedParts []*s3.CompletedPart
+}
+
+// This run function will load the parts from the channel and send them to S3, after initializing the transfer.
+// This is called by the Service's eternally running goroutine after receiving the upload request from a channel.
+func (u *Upload) Run() error {
+	if u.uploadId == nil {
+		if err := u.initS3Upload(); err != nil {
+			// Errors are returned to the calling functions through the notifier channel.
+			// returning error here allows for the upload to be sent back to incomplete status.
+			//
+			// In this case, it shouldn't be sent back to incomplete, as the upload never even started.
+			u.notifier <- errStatus(InitError{err})
+			return nil
+		}
+	}
+
+	for {
+		select {
+		case <-time.After(u.s.Timeout):
+			return ErrTimeout
+		case part := <-u.parts:
+			//TODO: max retries
+			if err := u.uploadPart(part); err != nil {
+				return UploadError{err}
+			}
+			u.notifier <- UploadStatus{
+				Code:    UploadStatusCodeProgress,
+				Message: strconv.Itoa(u.Uploaded),
+			}
+			if len(u.completedParts) != cap(u.completedParts) {
+				continue
+			}
+			if err := u.completeUpload(); err != nil {
+				return UploadError{err}
+			}
+			u.notifier <- UploadStatus{
+				Code:    UploadStatusCodeOk,
+				Message: "Upload completed",
+			}
+			return nil
+		}
+	}
+}
+
+func (u *Upload) initS3Upload() error {
+	resp, err := u.s.Client.CreateMultipartUpload(&s3.CreateMultipartUploadInput{
+		Bucket: aws.String(u.s.Bucket),
+		Key:    aws.String(u.Filepath),
+	})
+	if err != nil {
+		return err
+	}
+	u.uploadId = resp.UploadId
+	return nil
+}
+
+func (u *Upload) uploadPart(part []byte) error {
+	currPartNum := len(u.completedParts) + 1
+
+	res, err := u.s.Client.UploadPart(&s3.UploadPartInput{
+		Body:          bytes.NewReader(part),
+		Bucket:        aws.String(u.s.Bucket),
+		Key:           aws.String(u.Filepath),
+		PartNumber:    aws.Int64(int64(currPartNum)),
+		UploadId:      u.uploadId,
+		ContentLength: aws.Int64(int64(len(part))),
+	})
+	if err != nil {
+		return err
+	}
+
+	u.Uploaded += len(part)
+	u.completedParts = append(u.completedParts, &s3.CompletedPart{
+		PartNumber: aws.Int64(int64(currPartNum)),
+		ETag:       res.ETag,
+	})
+	return nil
+}
+
+func (u *Upload) completeUpload() error {
+	_, err := u.s.Client.CompleteMultipartUpload(&s3.CompleteMultipartUploadInput{
+		Bucket:   aws.String(u.s.Bucket),
+		Key:      aws.String(u.Filepath),
+		UploadId: u.uploadId,
+		MultipartUpload: &s3.CompletedMultipartUpload{
+			Parts: u.completedParts,
+		},
+	})
+	return err
+}
+
+// This function sends to the parts channel from the reader.
+func (u *Upload) Send() {
+	for {
+		b := make([]byte, u.s.ChunkSizeLimit)
+		n, err := u.R.Read(b)
+		if err == io.EOF {
+			// do nothing!
+			return
+		}
+		if err != nil {
+			u.notifier <- errStatus(err)
+			return
+		}
+		if n == 0 {
+			continue
+		}
+
+		u.parts <- b[:n]
+	}
+}


### PR DESCRIPTION
main.go is still there because connect still uses it (i dont think LM uses it at all). 
Once connect is migrated we can remove this file. 