### PR TITLE
fix: max iterations for redis match functions

### DIFF
--- a/redis/cache.go
+++ b/redis/cache.go
@@ -124,6 +124,10 @@ func (c *Cache) SearchRedis(match string, cursor, limit int) ([]string, int, err
 	return c.Redis.ScanAtLeast(match, cursor, limit)
 }
 
+func (c *Cache) SearchRedisWithMaxIter(match string, cursor, limit int, maxIter int) ([]string, int, error) {
+	return c.Redis.ScanAtLeastWithMaxIter(match, cursor, limit, maxIter)
+}
+
 func (c *Cache) DeleteKeyMatch(match string) (int, error) {
 	return c.Redis.DeleteKeyMatchFn(match, c.del)
 }


### PR DESCRIPTION
Introduces IterationLimit for redis match functions to stop infinite loop. 

Two potential infinite loops
- DeleteMatchFn 
- ScanAtLeast