### PR TITLE
MatchesCode pg ErrorConfig & Escape ILIKE "_" and "%"

### DIFF
--- a/db/postgres/error.go
+++ b/db/postgres/error.go
@@ -2,6 +2,12 @@ package pgUtils
 
 import "github.com/lib/pq"
 
+const (
+	ErrCodeConflict   pq.ErrorCode = "23503"
+	ErrCodeIncomplete pq.ErrorCode = "22P02"
+	ErrCodeDuplicate  pq.ErrorCode = "23505"
+)
+
 type ErrorConfig interface {
 	Test(e *pq.Error) bool
 }
@@ -10,6 +16,12 @@ type MatchesConstraint string
 
 func (c MatchesConstraint) Test(e *pq.Error) bool {
 	return e.Constraint == string(c)
+}
+
+type MatchesCode pq.ErrorCode
+
+func (c MatchesCode) Test(e *pq.Error) bool {
+	return e.Code == pq.ErrorCode(c)
 }
 
 // Transforms the error coming in *if* it is a PG error, based on the

--- a/db/postgres/search-string.go
+++ b/db/postgres/search-string.go
@@ -2,6 +2,7 @@ package pgUtils
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Masterminds/squirrel"
 
@@ -35,7 +36,15 @@ type SearchOperatorConfigStringLike struct {
 }
 
 func (c SearchOperatorConfigStringLike) Sqlizer(o operator.Operator, prefix string) squirrel.Sqlizer {
-	return squirrel.Expr(fmt.Sprintf("%s%s%s ILIKE ?", prefix, c.Field, doNot(o)), "%"+o.Value+"%")
+	// Escape _
+	parts := strings.Split(o.Value, "_")
+	value := strings.Join(parts, "\\_")
+
+	// Escape the %
+	parts = strings.Split(value, "%")
+	value = strings.Join(parts, "\\%")
+
+	return squirrel.Expr(fmt.Sprintf("%s%s%s ILIKE ?", prefix, c.Field, doNot(o)), "%"+value+"%")
 }
 func (c SearchOperatorConfigStringLike) Apply(os, rem []operator.Operator, a *Accumulator, prefix string) {
 	fn := func(o operator.Operator) squirrel.Sqlizer {


### PR DESCRIPTION
- Adds a MatchesCode for use with TransformError which matches the error to a postgres Code 
- Fix ILIKE by escaping the _, % https://www.postgresql.org/docs/9.0/functions-matching.html