### PR TITLE
Update Operator Parser to use a Delegate

### DIFF
--- a/db/postgres/search-bool.go
+++ b/db/postgres/search-bool.go
@@ -13,7 +13,7 @@ func NewBoolOperator(field string, keys ...string) SearchOperatorConfigBool {
 	return SearchOperatorConfigBool{
 		SearchOperatorConfigBase{
 			Field: field,
-			Keys: keys,
+			Keys:  keys,
 		},
 	}
 }
@@ -35,7 +35,11 @@ func parseBool(o string) bool {
 
 func (c SearchOperatorConfigBool) Apply(os, rem []operator.Operator, a *Accumulator, prefix string) {
 	loopOperators(os, a, func(o operator.Operator) squirrel.Sqlizer {
-		b := parseBool(o.Value)
+		if len(o.Values) == 0 {
+			return nil
+		}
+		val := o.Values[0]
+		b := parseBool(val)
 		if o.Has(operator.ModifierNot) {
 			b = !b
 		}

--- a/db/postgres/search-string.go
+++ b/db/postgres/search-string.go
@@ -5,20 +5,21 @@ import (
 	"strings"
 
 	"github.com/Masterminds/squirrel"
+	"github.com/lib/pq"
 
 	"github.com/monstercat/golib/operator"
 )
 
-func NewStringSearchOperator(field string, keys ...string) SearchOperatorConfigBase {
+func NewSearchOperatorConfigBase(field string, keys ...string) SearchOperatorConfigBase {
 	return SearchOperatorConfigBase{Field: field, Keys: keys}
 }
 
 func NewUUIDOperator(field string, keys ...string) SearchOperatorConfigUUID {
-	return SearchOperatorConfigUUID{NewStringSearchOperator(field, keys...)}
+	return SearchOperatorConfigUUID{NewSearchOperatorConfigBase(field, keys...)}
 }
 
 func NewStringLikeOperator(field string, keys ...string) SearchOperatorConfigStringLike {
-	return SearchOperatorConfigStringLike{NewStringSearchOperator(field, keys...)}
+	return SearchOperatorConfigStringLike{NewSearchOperatorConfigBase(field, keys...)}
 }
 
 type SearchOperatorConfigUUID struct {
@@ -27,7 +28,7 @@ type SearchOperatorConfigUUID struct {
 
 func (c SearchOperatorConfigUUID) Apply(os, rem []operator.Operator, a *Accumulator, prefix string) {
 	loopOperators(os, a, func(o operator.Operator) squirrel.Sqlizer {
-		return squirrel.Expr(fmt.Sprintf("%s%s%s = ?", prefix, c.Field, doNot(o)), o.Value)
+		return squirrel.Expr(fmt.Sprintf("%s%s%s = ANY(?)", prefix, c.Field, doNot(o)), pq.StringArray(o.Values))
 	})
 }
 
@@ -36,16 +37,21 @@ type SearchOperatorConfigStringLike struct {
 }
 
 func (c SearchOperatorConfigStringLike) Sqlizer(o operator.Operator, prefix string) squirrel.Sqlizer {
-	// Escape _
-	parts := strings.Split(o.Value, "_")
-	value := strings.Join(parts, "\\_")
+	and := squirrel.And{}
+	for _, v := range o.Values {
+		// Escape _
+		parts := strings.Split(v, "_")
+		value := strings.Join(parts, "\\_")
 
-	// Escape the %
-	parts = strings.Split(value, "%")
-	value = strings.Join(parts, "\\%")
+		// Escape the %
+		parts = strings.Split(value, "%")
+		value = strings.Join(parts, "\\%")
 
-	return squirrel.Expr(fmt.Sprintf("%s%s%s ILIKE ?", prefix, c.Field, doNot(o)), "%"+value+"%")
+		and = append(and, squirrel.Expr(fmt.Sprintf("%s%s%s ILIKE ?", prefix, c.Field, doNot(o)), "%"+value+"%"))
+	}
+	return and
 }
+
 func (c SearchOperatorConfigStringLike) Apply(os, rem []operator.Operator, a *Accumulator, prefix string) {
 	fn := func(o operator.Operator) squirrel.Sqlizer {
 		return c.Sqlizer(o, prefix)
@@ -53,4 +59,3 @@ func (c SearchOperatorConfigStringLike) Apply(os, rem []operator.Operator, a *Ac
 	loopOperators(os, a, fn)
 	applyRemainders(rem, a, fn)
 }
-

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -2,23 +2,70 @@ package operator
 
 type Operators struct {
 	// Map of key to operator
-	Values     map[string][]Operator
+	Values map[string][]Operator
 
 	// Remainders
 	Remainders []Operator
+
+	// Any Errors related to parsing of the operator.
+	Errors []error
 }
 
-func (o *Operators) AddRemainder(str string) {
+// Equals returns true of the provided operators is the same as the current one.
+func (o *Operators) Equals(b *Operators) bool {
+	if len(o.Remainders) != len(b.Remainders) {
+		return false
+	}
+	if len(o.Values) != len(b.Values) {
+		return false
+	}
+	for _, r := range o.Remainders {
+		var found bool
+		for _, br := range b.Remainders {
+			if r.Equals(br) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	for k, v := range o.Values {
+		existing, ok := b.Values[k]
+		if !ok {
+			return false
+		}
+		if len(existing) != len(v) {
+			return false
+		}
+		for _, o := range v {
+			var found bool
+			for _, bo := range existing {
+				if o.Equals(bo) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (o *Operators) AddRemainder(str ...string) {
 	if len(str) == 0 {
 		return
 	}
 	o.Remainders = append(o.Remainders, Operator{
-		Value: str,
+		Values: str,
 	})
 }
 
 func (o *Operators) AddOperator(key string, op Operator) {
-	if len(op.Value) == 0 {
+	if len(op.Values) == 0 {
 		return
 	}
 	m, ok := o.Values[key]
@@ -38,9 +85,52 @@ func (o *Operators) GetOperatorValues(key string) []string {
 	return GetOperatorValues(ops)
 }
 
+// Operator defines a set of values and modifiers that go along with those values. Most operators contain only a single
+// value, but prepare to handle multiple values.
+//
+// 2022-09-28 - Note that this is a breaking change from previous versions.
 type Operator struct {
-	Value     string
+	// Values representative of this operator.
+	Values []string
+
+	// Modifiers associated with the operator.
 	Modifiers []Modifier
+}
+
+// Equals returns true of the provided operator is the same as the current one.
+func (o *Operator) Equals(b Operator) bool {
+	if len(o.Modifiers) != len(b.Modifiers) {
+		return false
+	}
+	if len(o.Values) != len(b.Values) {
+		return false
+	}
+	for _, m := range o.Modifiers {
+		var found bool
+		for _, bm := range b.Modifiers {
+			if bm == m {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	for _, v := range o.Values {
+		var found bool
+		for _, bv := range b.Values {
+			if v == bv {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 func (o *Operator) Has(m Modifier) bool {
@@ -61,7 +151,7 @@ func GetOperatorValues(ops []Operator) []string {
 	}
 	xs := make([]string, 0, len(ops))
 	for _, o := range ops {
-		xs = append(xs, o.Value)
+		xs = append(xs, o.Values...)
 	}
 	return xs
 }

--- a/operator/parser-config.go
+++ b/operator/parser-config.go
@@ -1,0 +1,211 @@
+package operator
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+var (
+	ErrParserInvalidMatch = errors.New("could not parser regexp matches")
+)
+
+// ParserRegexpDelegate is an interface that the Parser uses to help perform its work in producing operators. The Parser
+// will delegate responsibility to the provided implementation.
+type ParserRegexpDelegate interface {
+	// Regexp function should return a single regular expression which parses for 1 operator, keeping in mind
+	// remainders and modifiers.
+	Regexp() (*regexp.Regexp, error)
+
+	// ParseMatch parses the provided match to return:
+	// - modifiers
+	// - key
+	// - value
+	//
+	// Depending on the return values, the Parser will either:
+	// - exclude it
+	// - include it as an operator
+	// - include it as a remainder.
+	ParseMatch(match []string) (mods []Modifier, key string, value []string, err error)
+
+	// ParseMapKey decodes the input key by splitting out its modifiers.This is used for the Parser.ParseMap
+	// functionality.
+	ParseMapKey(inputKey string) (mods []Modifier, key string, err error)
+}
+
+// ParserDelegateSatDefaultModifiers is an optional interface allowing setting of "default" modifiers (e.g., in the case
+// none are provided). This is for backwards compatibility and will be removed in the future.
+//
+// @DEPRECATED
+type ParserDelegateSatDefaultModifiers interface {
+	// SetDefaultModifiers should store the provided modifiers as the modifiers used in the REGEXP and the ParseMapKey
+	// function IF another set of modifiers hasn't already been set.
+	SetDefaultModifiers(m ...Modifier)
+}
+
+// ParserConfig implements ParserRegexpDelegate. It looks for operators of the form
+//
+//	[modifier-character][key][key-delimiter][str-start][stuff][str-end]
+//
+// For example, if StringStart and StringEnd were " and the keyDelimiter was =, an example operator would be
+//
+//	key="value"
+//	!key="value"
+//
+// The key and the string delimiters are optional.
+//
+// Naming of ParserConfig is to ensure backwards compatibility for users that still use this. In the future, it will
+// be changed to DefaultParserDelegate.
+//
+// @DEPRECATED
+type ParserConfig struct {
+	// String start and end characters.
+	StringStart string
+	StringEnd   string
+
+	// Key delimiting character
+	KeyDelimiter string
+
+	// List of modifier runes.
+	Modifiers []Modifier
+
+	// Cache for the keyRegexp, so it only has to be generated once.
+	keyRegexp *regexp.Regexp
+
+	// Cache for the string regexp, so it only has to be generated once.
+	stringRegexp *regexp.Regexp
+}
+
+func (c *ParserConfig) SetDefaultModifiers(m ...Modifier) {
+	c.Modifiers = m
+}
+
+func (c *ParserConfig) regexpKeyString() string {
+	return fmt.Sprintf("([%s]*)([\\w-]+)", regexp.QuoteMeta(string(c.Modifiers)))
+}
+
+func (c *ParserConfig) regexpString() string {
+	return fmt.Sprintf("(%s%s)?([^%s%s\\s]+|%[3]s([^%[4]s]+)%[4]s)",
+		c.regexpKeyString(),
+		regexp.QuoteMeta(c.KeyDelimiter),
+		regexp.QuoteMeta(c.StringStart),
+		regexp.QuoteMeta(c.StringEnd),
+	)
+}
+
+// Regexp function should return a single regular expression which parses for 1 operator, keeping in mind
+// remainders and modifiers.
+func (c *ParserConfig) Regexp() (r *regexp.Regexp, err error) {
+	if c.stringRegexp == nil {
+		c.stringRegexp, err = regexp.Compile(c.regexpString())
+		if err != nil {
+			return
+		}
+	}
+	return c.stringRegexp, nil
+}
+
+// ParseMatch parses the provided match to return:
+// - modifiers
+// - key
+// - value
+//
+// Match has the same values as regexp.FindSubmatchString
+func (c *ParserConfig) ParseMatch(match []string) (mods []Modifier, key string, value []string, err error) {
+	if len(c.Modifiers) == 0 {
+		return c.parseMatchNoMods(match)
+	}
+	return c.parseMatch(match)
+}
+
+// parseMatch is meant to parse the match if there are modifiers.
+func (c *ParserConfig) parseMatch(match []string) (mods []Modifier, key string, value []string, err error) {
+	// Based on the regexp string, the indices are
+	// 0 - the whole value  (ignore)
+	// 1 - the key part including the delmiter & the tag (ignore)
+	// 2 - the modifiers, if any
+	// 3 - the key
+	// 4 - the value but including the string start and string end
+	// 5 - the value
+	//
+	// Thus, the length should be 6. If itt isn't we ignore.
+	//
+	// Based on the regexp, we don't need to check for Modifier validity as it is already valid out of the box.
+	if len(match) != 6 {
+		err = ErrParserInvalidMatch
+		return
+	}
+
+	// Note that 4 and 5 cannot be ignored. There is a possibility that 5 is empty due to the way the regexp is
+	// constructed.
+	switch match[5] {
+	case "":
+		value = []string{match[4]}
+	default:
+		value = []string{match[5]}
+	}
+
+	key = match[3]
+	for _, b := range []rune(match[2]) {
+		mods = append(mods, Modifier(b))
+	}
+	return
+}
+
+// parseMatchNoMods is meant to parse the match if there are no modifiers.
+func (c *ParserConfig) parseMatchNoMods(match []string) (mods []Modifier, key string, value []string, err error) {
+	// Based on the regexp string, the indices are
+	// 0 - the whole value  (ignore)
+	// 1 - the key part including the delmiter & the tag (ignore)
+	// 2 - the key
+	// 3 - the value but including the string start and string end
+	// 4 - the value
+	//
+	// Thus, the length should be 6. If itt isn't we ignore.
+	//
+	// Based on the regexp, we don't need to check for Modifier validity as it is already valid out of the box.
+	if len(match) != 5 {
+		err = ErrParserInvalidMatch
+		return
+	}
+
+	// Note that 4 and 5 cannot be ignored. There is a possibility that 5 is empty due to the way the regexp is
+	// constructed.
+	switch match[4] {
+	case "":
+		value = []string{match[3]}
+	default:
+		value = []string{match[4]}
+	}
+
+	key = match[2]
+	return
+}
+
+// ParseMapKey decodes the input key by splitting out its modifiers.This is used for the Parser.ParseMap
+// functionality.
+func (c *ParserConfig) ParseMapKey(inputKey string) (mods []Modifier, key string, err error) {
+	if c.keyRegexp == nil {
+		c.keyRegexp, err = regexp.Compile(c.regexpKeyString())
+		if err != nil {
+			return
+		}
+	}
+
+	matches := c.keyRegexp.FindStringSubmatch(inputKey)
+
+	// There should be 3 matches.
+	// 0 - The whole key
+	// 1 - The modifiers, if any
+	// 2 - The actual key without modifiers.
+	if len(matches) != 3 {
+		err = ErrParserInvalidMatch
+		return
+	}
+
+	key = matches[2]
+	for _, b := range []rune(matches[1]) {
+		mods = append(mods, Modifier(b))
+	}
+	return
+}

--- a/operator/parser-error.go
+++ b/operator/parser-error.go
@@ -1,0 +1,44 @@
+package operator
+
+import "fmt"
+
+// ParseMapKeyError is an error related to parsing of a map key. It wraps the error returned from
+// ParserRegexpDelegate.ParseMapKey
+type ParseMapKeyError struct {
+	// The error in question
+	Base error
+
+	// InputKey which caused the error.
+	InputKey string
+}
+
+// Error string
+func (e *ParseMapKeyError) Error() string {
+	return fmt.Sprintf("Input key '%s' has been ignored. %s", e.InputKey, e.Base)
+}
+
+// ParseRegexpError occurs when regexp could not be parsed properly for Parser.Parse.
+type ParseRegexpError struct {
+	// The error in question
+	Base error
+}
+
+// Error string
+func (e *ParseRegexpError) Error() string {
+	return fmt.Sprintf("Regexp could not be compiled. %s", e.Base)
+}
+
+// ParseMatchError is an error related to the parsing of a match. It wraps the error returned from
+// ParserRegexpDelegate.ParseMatch
+type ParseMatchError struct {
+	// Matches that were returned, if any.
+	Matches []string
+
+	// The error in question
+	Base error
+}
+
+// Error string
+func (e *ParseMatchError) Error() string {
+	return fmt.Sprintf("Could not parse provided match. %s", e.Base)
+}

--- a/operator/parser.go
+++ b/operator/parser.go
@@ -1,52 +1,46 @@
 package operator
 
 import (
-	"fmt"
-	"regexp"
+	"errors"
 	"strings"
-
-	stringutil "github.com/monstercat/golib/string"
 )
 
 var (
-	ValidOperatorRegexp = regexp.MustCompile("^[A-z\\-]+$")
+	ErrInvalidDelegate = errors.New("invalid delegate")
 )
 
+// Parser parses maps/strings into operators using the provided delegate to modify its behaviour. Currently, the only
+// delegate possible is the Regexp delegate. This delegate will ParseMatch based on a Regexp returned by the delegate
+// and a corresponding ParseMatch function.
 type Parser struct {
-	// Modifiers that the parser will check.
-	Modifiers      []Modifier
-	KeyValueRegexp *regexp.Regexp
+	// Delegate modifies the operation of the parser.
+	//
+	// TODO: Currently, only a Regexp parser is supported, but in the future, this should be extracted to extended to
+	//   allow for other types of parsers.
+	Delegate ParserRegexpDelegate
 }
 
-type ParserConfig struct {
-	// String start and end characters.
-	StringStart string
-	StringEnd   string
-
-	// Key delimiting character
-	KeyDelimiter string
-}
-
-func (c *ParserConfig) regexpString() string {
-	return fmt.Sprintf("(([\\w-]+)%s)?([^%s%s\\s]+|%[2]s([^%[3]s]+)%[3]s)",
-		regexp.QuoteMeta(c.KeyDelimiter),
-		regexp.QuoteMeta(c.StringStart),
-		regexp.QuoteMeta(c.StringEnd),
-	)
-}
-
-func (c *ParserConfig) Regexp() (*regexp.Regexp, error) {
-	return regexp.Compile(c.regexpString())
-}
-
-func NewParser(config ParserConfig) (*Parser, error) {
-	regexp, err := config.Regexp()
-	if err != nil {
-		return nil, err
+// NewParser generates a new parser based on the provided delegate. If defined, it will also set default modifiers.
+//
+// Unfortunately, the delegate does not work because we used to take in ParserConfig (note: missing the pointer).
+// However, it currently wants &ParserConfig. Thus, we use interface{}.
+func NewParser(delegate interface{}) (*Parser, error) {
+	var d ParserRegexpDelegate
+	switch v := delegate.(type) {
+	case ParserRegexpDelegate:
+		d = v
+	case ParserConfig:
+		d = &v
+	default:
+		return nil, ErrInvalidDelegate
 	}
+
+	if v, ok := d.(ParserDelegateSatDefaultModifiers); ok {
+		v.SetDefaultModifiers(Modifiers...)
+	}
+
 	return &Parser{
-		Modifiers:      Modifiers,
-		KeyValueRegexp: regexp,
+		Delegate: d,
 	}, nil
 }
 
@@ -63,24 +57,24 @@ func (p *Parser) ParseMap(m map[string][]string) Operators {
 		if len(vv) == 0 {
 			continue
 		}
+
 		// In the case that k is empty string, we can ignore.
 		if len(k) == 0 {
 			continue
 		}
 
-		// Retrieve modifiers. Modifiers are defined currently as the first character of the key. However, this might
-		// need to change as there might be more than 1 modifier.
-		currModifiers := make([]Modifier, 0, len(p.Modifiers))
-		if mod := p.MatchModifier(k[0]); mod != nil {
-			currModifiers = append(currModifiers, *mod)
-			k = k[1:]
-		}
-		for _, v := range vv {
-			operators.AddOperator(k, Operator{
-				Value:     v,
-				Modifiers: currModifiers,
+		mods, key, err := p.Delegate.ParseMapKey(k)
+		if err != nil {
+			operators.Errors = append(operators.Errors, &ParseMapKeyError{
+				Base:     err,
+				InputKey: k,
 			})
+			continue
 		}
+		operators.AddOperator(key, Operator{
+			Values:    vv,
+			Modifiers: mods,
+		})
 	}
 	return operators
 }
@@ -93,138 +87,45 @@ func (p *Parser) Parse(str string) Operators {
 		Values:     make(map[string][]Operator),
 		Remainders: make([]Operator, 0, 10),
 	}
-	currModifiers := make([]Modifier, 0, len(p.Modifiers))
 
-	for i := 0; i < len(str); i++ {
-		// Ignore spaces
-		if str[i] == ' ' {
+	// Get the regexp. If we cannot, just return the operators.
+	r, err := p.Delegate.Regexp()
+	if err != nil {
+		operators.Errors = append(operators.Errors, &ParseRegexpError{Base: err})
+		return operators
+	}
+
+	// Get all matches
+	matches := r.FindAllStringSubmatch(str, -1)
+	if matches == nil {
+		return operators
+	}
+
+	for _, m := range matches {
+		mods, key, value, err := p.Delegate.ParseMatch(m)
+		if err != nil {
+			// On any error, it should continue. Note that this is for backwards compatibility. The function signature
+			// does not allow for parser errors. In the case of parser errors, the whole match should be ignored.
 			continue
 		}
 
-		// Check for existence of modifiers.
-		if m := p.MatchModifier(str[i]); m != nil {
-			currModifiers = append(currModifiers, *m)
+		// Ignore anything that is missing the value.
+		if len(value) == 0 {
 			continue
 		}
 
-		// If no modifiers, we can continue to look for a key or a
-		// value. If there is a ":" then it's a key. What comes next
-		// is the value (unless there is a space, in which case we need to
-		// ignore it).
-		key, value, n := p.FindKeyOrValue(str[i:])
-		if n == 0 {
-			continue
-		}
-
+		// if the key is empty, it's a remainder. We ignore the mods (there shouldn't be any).
 		if key == "" {
-			operators.AddRemainder(value)
-		} else {
-			operators.AddOperator(key, Operator{
-				Value:     value,
-				Modifiers: currModifiers,
-			})
+			operators.AddRemainder(value...)
+			continue
 		}
 
-		// Reset the modifiers and increment the index
-		i += n
-		currModifiers = make([]Modifier, 0, len(p.Modifiers))
+		// Otherwise, we add the operator
+		operators.AddOperator(key, Operator{
+			Values:    value,
+			Modifiers: mods,
+		})
 	}
 
 	return operators
-}
-
-func (p *Parser) MatchModifier(str byte) *Modifier {
-	for _, m := range p.Modifiers {
-		if m.Matches(str) {
-			return &m
-		}
-	}
-	return nil
-}
-
-func (p *Parser) FindKeyOrValue(str string) (key string, value string, n int) {
-	matchIdx := p.KeyValueRegexp.FindStringSubmatchIndex(str)
-
-	// The match should occur right at the beginning
-	if matchIdx == nil || matchIdx[0] != 0 || matchIdx[2] > 0 {
-		return "", "", 0
-	}
-
-	// The length of the total match is the second argument.
-	n = matchIdx[1]
-
-	// After that there are either 2 or 4 subgroups.
-	if matchIdx[2] == -1 || matchIdx[4] == -1 {
-		key = ""
-	} else {
-		key = str[:matchIdx[5]]
-	}
-
-	// There's a problem! I need to have 10 indices
-	if len(matchIdx) != 10 {
-		return "", "", n
-	}
-
-	if matchIdx[8] == -1 {
-		value = str[matchIdx[6]:matchIdx[7]]
-	} else {
-		value = str[matchIdx[8]:matchIdx[9]]
-	}
-
-	return
-}
-
-func (p *Parser) RemoveOperatorsFromString(str string, operators ...string) string {
-	validOperators := make([]string, 0, len(operators))
-	for _, o := range operators {
-		if ValidOperatorRegexp.MatchString(o) {
-			validOperators = append(validOperators, o)
-		}
-	}
-	if len(validOperators) == 0 {
-		return str
-	}
-
-	var res string
-	for i := 0; i < len(str); i++ {
-		l := len(res)
-
-		// Ignore spaces
-		if str[i] == ' ' {
-			if l > 0 && res[l-1] != ' ' {
-				res = res + " "
-			}
-			continue
-		}
-
-		search := i
-		if p.MatchModifier(str[i]) != nil {
-			search++
-		}
-		key, _, n := p.FindKeyOrValue(str[i:])
-		if !stringutil.StringInList(validOperators, key) {
-			res = res + str[i:search+n]
-		}
-
-		// as the for loop will continue to increment i we need to -1
-		if search+n > i {
-			i = search + n - 1
-		}
-		continue
-	}
-	return strings.TrimSpace(res)
-}
-
-func OperatorExtractComparator(v string) (string, string) {
-	switch {
-	case strings.HasPrefix(v, "="):
-		return v[1:], "="
-	case strings.HasPrefix(v, ">"), strings.HasPrefix(v, "<"):
-		if v[1] == '=' {
-			return v[2:], v[0:2]
-		}
-		return v[1:], v[0:1]
-	default:
-		return v, "="
-	}
 }

--- a/operator/parser_test.go
+++ b/operator/parser_test.go
@@ -2,159 +2,8 @@ package operator
 
 import (
 	"net/url"
-	"regexp"
 	"testing"
 )
-
-func TestParserConfig_Regexp(t *testing.T) {
-
-	tests := []struct {
-		c ParserConfig
-		s string
-	}{
-		{
-			c: ParserConfig{
-				StringStart:  ">",
-				StringEnd:    "<",
-				KeyDelimiter: "-",
-			},
-			s: "(([\\w-]+)-)?([^><\\s]+|>[^<]+<)",
-		},
-		{
-			c: ParserConfig{
-				StringStart:  "\"",
-				StringEnd:    "\"",
-				KeyDelimiter: ":",
-			},
-			s: "(([\\w-]+):)?([^\"\"\\s]+|\"[^\"]+\")",
-		},
-		{
-			c: ParserConfig{
-				StringStart:  "?",
-				StringEnd:    "!",
-				KeyDelimiter: "+",
-			},
-			s: "(([\\w-]+)\\+)?([^\\?!\\s]+|\\?[^!]+!)",
-		},
-	}
-
-	for i, test := range tests {
-		s := test.c.regexpString()
-		if s != test.s {
-			t.Errorf("[%d] did not match", i)
-		}
-		_, err := regexp.Compile(s)
-		if err != nil {
-			t.Errorf("[%d] did not compile: %s", i, err)
-		}
-	}
-}
-
-func TestParser_RemoveOperatorsFromString(t *testing.T) {
-	parser, err := NewParser(ParserConfig{
-		StringStart:  "\"",
-		StringEnd:    "\"",
-		KeyDelimiter: ":",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	tests := []struct {
-		Remove []string
-		Start  string
-		Result string
-	}{
-		{
-			Remove: []string{"state"},
-			Start:  "state:12345",
-			Result: "",
-		},
-		{
-			Remove: []string{"state"},
-			Start:  "state:12345 title:12345 43939",
-			Result: "title:12345 43939",
-		},
-		{
-			Remove: []string{"state"},
-			Start:  "title:12345 state:12345 43939",
-			Result: "title:12345 43939",
-		},
-		{
-			Remove: []string{"state", "title"},
-			Start:  "title:12345 state:12345 43939",
-			Result: "43939",
-		},
-	}
-
-	for _, test := range tests {
-		res := parser.RemoveOperatorsFromString(test.Start, test.Remove...)
-		if res != test.Result {
-			t.Errorf("For `%s`, removing %#v... got `%s`, expected `%s`", test.Start, test.Remove, res, test.Result)
-		}
-	}
-}
-
-func TestParser_FindKeyOrValue(t *testing.T) {
-	c := ParserConfig{
-		StringStart:  "\"",
-		StringEnd:    "\"",
-		KeyDelimiter: ":",
-	}
-	regexp, err := c.Regexp()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	p := &Parser{
-		KeyValueRegexp: regexp,
-	}
-
-	tests := []struct {
-		s     string
-		key   string
-		value string
-		n     int
-	}{
-		{
-			s:     "tag:123456 tags:\"123454-fjgie\"",
-			key:   "tag",
-			value: "123456",
-			n:     10,
-		},
-		{
-			s:     "123456 tags:\"123454-fjgie\"",
-			key:   "",
-			value: "123456",
-			n:     6,
-		},
-		{
-			s:     "\"123454-fjgie\" tag:12309",
-			key:   "",
-			value: "123454-fjgie",
-			n:     14,
-		},
-		{
-			s:     "tags:\"123454-fjgie\" blah-blah:1234j",
-			key:   "tags",
-			value: "123454-fjgie",
-			n:     19,
-		},
-	}
-
-	for i, test := range tests {
-		key, value, n := p.FindKeyOrValue(test.s)
-		if n != test.n {
-			t.Errorf("[%d] number of chars does not match, got %d; expect %d", i, n, test.n)
-		}
-		if key != test.key {
-			t.Errorf("[%d] key does not match. Got %s expect %s", i, key, test.key)
-		}
-		if value != test.value {
-			t.Errorf("[%d] value does not match. Got %s, expect %s", i, value, test.value)
-		}
-	}
-}
 
 func TestParser_Parse(t *testing.T) {
 
@@ -176,10 +25,10 @@ func TestParser_Parse(t *testing.T) {
 			ops: Operators{
 				Values: map[string][]Operator{
 					"tag": {{
-						Value: "123456",
+						Values: []string{"123456"},
 					}},
 					"tags": {{
-						Value: "123454-fjgie",
+						Values: []string{"123454-fjgie"},
 					}},
 				},
 			},
@@ -190,15 +39,15 @@ func TestParser_Parse(t *testing.T) {
 				Values: map[string][]Operator{
 					"tag": {
 						{
-							Value: "123456",
+							Values: []string{"123456"},
 						},
 						{
-							Value:     "54949",
+							Values:    []string{"54949"},
 							Modifiers: []Modifier{ModifierNot},
 						},
 					},
 					"tags": {{
-						Value: "123454-fjgie",
+						Values: []string{"123454-fjgie"},
 					}},
 				},
 			},
@@ -209,17 +58,17 @@ func TestParser_Parse(t *testing.T) {
 				Values: map[string][]Operator{
 					"tag": {
 						{
-							Value:     "54949",
+							Values:    []string{"54949"},
 							Modifiers: []Modifier{ModifierNot},
 						},
 					},
 					"tags": {{
-						Value: "123454-fjgie",
+						Values: []string{"123454-fjgie"},
 					}},
 				},
 				Remainders: []Operator{
 					{
-						Value: "123456",
+						Values: []string{"123456"},
 					},
 				},
 			},
@@ -228,50 +77,21 @@ func TestParser_Parse(t *testing.T) {
 
 	for i, test := range tests {
 		ops := p.Parse(test.s)
-		if len(ops.Remainders) != len(test.ops.Remainders) {
-			t.Errorf("[%d] remainders not equal length. Got %d, want %d", i, len(ops.Remainders), len(test.ops.Remainders))
-		}
-		for _, r := range test.ops.Remainders {
-			var found bool
-			for _, rem := range ops.Remainders {
-				if r.Value == rem.Value {
-					found = true
-					break
-				}
-			}
-			if !found {
-				t.Errorf("[%d] expecting remainder %s, but cannot find in list", i, r.Value)
-			}
-		}
-		for key, val := range ops.Values {
-			testVal, ok := test.ops.Values[key]
-			if !ok {
-				t.Errorf("[%d] expecting an operator value at key %s; but there is none", i, key)
-				continue
-			}
-			if len(val) != len(testVal) {
-				t.Errorf("[%d] expecting %d operators for key %s; but got %d", i, len(testVal), key, len(val))
-				continue
-			}
-			for j, v := range val {
-				if v.Value != testVal[j].Value {
-					t.Errorf("[%d] expecting operator value %s for key %s at idx %d; but got %s", i, testVal[j].Value, key, j, v.Value)
-				}
-				if len(v.Modifiers) != len(testVal[j].Modifiers) {
-					t.Errorf("[%d] expecting %d modifiers but got %d for key %s at idx %d", i, len(testVal[j].Modifiers), len(v.Modifiers), key, j)
-				}
-				for k, m := range v.Modifiers {
-					if m != testVal[j].Modifiers[k] {
-						t.Errorf("[%d] Expecting modifier %v but got %v for key %s at idx %d", i, testVal[j].Modifiers[k], m, key, j)
-					}
-				}
-			}
+		if !ops.Equals(&test.ops) {
+			t.Errorf(`[%d] Operator is not as expected. 
+       Expected: %#v
+	   Actual: %#v
+`,
+				i,
+				test.ops,
+				ops,
+			)
 		}
 	}
 }
 
 func TestParser_ParseMap(t *testing.T) {
-	p, err := NewParser(ParserConfig{
+	p, err := NewParser(&ParserConfig{
 		StringStart:  "\"",
 		StringEnd:    "\"",
 		KeyDelimiter: ":",
@@ -286,23 +106,23 @@ func TestParser_ParseMap(t *testing.T) {
 	}{
 		{
 			s: url.Values{
-				"tag": []string{"123456"},
+				"tag":  []string{"123456"},
 				"tags": []string{"123454-fjgie"},
 			},
 			ops: Operators{
 				Values: map[string][]Operator{
 					"tag": {{
-						Value: "123456",
+						Values: []string{"123456"},
 					}},
 					"tags": {{
-						Value: "123454-fjgie",
+						Values: []string{"123454-fjgie"},
 					}},
 				},
 			},
 		},
 		{
 			s: url.Values{
-				"tag": []string{"123456"},
+				"tag":  []string{"123456"},
 				"tags": []string{"123454-fjgie"},
 				"!tag": []string{"54949"},
 			},
@@ -310,15 +130,15 @@ func TestParser_ParseMap(t *testing.T) {
 				Values: map[string][]Operator{
 					"tag": {
 						{
-							Value: "123456",
+							Values: []string{"123456"},
 						},
 						{
-							Value:     "54949",
+							Values:    []string{"54949"},
 							Modifiers: []Modifier{ModifierNot},
 						},
 					},
 					"tags": {{
-						Value: "123454-fjgie",
+						Values: []string{"123454-fjgie"},
 					}},
 				},
 			},
@@ -326,44 +146,15 @@ func TestParser_ParseMap(t *testing.T) {
 	}
 	for i, test := range tests {
 		ops := p.ParseMap(test.s)
-		if len(ops.Remainders) != len(test.ops.Remainders) {
-			t.Errorf("[%d] remainders not equal length. Got %d, want %d", i, len(ops.Remainders), len(test.ops.Remainders))
-		}
-		for _, r := range test.ops.Remainders {
-			var found bool
-			for _, rem := range ops.Remainders {
-				if r.Value == rem.Value {
-					found = true
-					break
-				}
-			}
-			if !found {
-				t.Errorf("[%d] expecting remainder %s, but cannot find in list", i, r.Value)
-			}
-		}
-		for key, val := range ops.Values {
-			testVal, ok := test.ops.Values[key]
-			if !ok {
-				t.Errorf("[%d] expecting an operator value at key %s; but there is none", i, key)
-				continue
-			}
-			if len(val) != len(testVal) {
-				t.Errorf("[%d] expecting %d operators for key %s; but got %d", i, len(testVal), key, len(val))
-				continue
-			}
-			for j, v := range val {
-				if v.Value != testVal[j].Value {
-					t.Errorf("[%d] expecting operator value %s for key %s at idx %d; but got %s", i, testVal[j].Value, key, j, v.Value)
-				}
-				if len(v.Modifiers) != len(testVal[j].Modifiers) {
-					t.Errorf("[%d] expecting %d modifiers but got %d for key %s at idx %d", i, len(testVal[j].Modifiers), len(v.Modifiers), key, j)
-				}
-				for k, m := range v.Modifiers {
-					if m != testVal[j].Modifiers[k] {
-						t.Errorf("[%d] Expecting modifier %v but got %v for key %s at idx %d", i, testVal[j].Modifiers[k], m, key, j)
-					}
-				}
-			}
+		if !ops.Equals(&test.ops) {
+			t.Errorf(`[%d] Operator is not as expected. 
+       Expected: %#v
+	   Actual: %#v
+`,
+				i,
+				test.ops,
+				ops,
+			)
 		}
 	}
 }


### PR DESCRIPTION
This delegate will be used to modify the behavior. It also:
- Adds Errors to operators, so we can tell which operators are causing errors
- Ensures that old logic will still work.