### PR TITLE
Adding FileServiceFileSize interface and GCS implementation

### DIFF
--- a/data/data-service.go
+++ b/data/data-service.go
@@ -85,6 +85,12 @@ type MD5Service interface {
 	MD5(filepath string) ([]byte, error)
 }
 
+// FilesizeService provides a way for a data service to return the size of a file
+// in bytes without downloading its contents.
+type FilesizeService interface {
+	Filesize(filepath string) (int64, error)
+}
+
 // SignedUrlService allows a service to return a signed URL for a filepath.
 type SignedUrlService interface {
 	SignedUrl(filepath string, tm time.Duration, cfg *SignedUrlConfig) (string, error)

--- a/gcp/storage/client.go
+++ b/gcp/storage/client.go
@@ -160,6 +160,19 @@ func (c *Client) MD5(filepath string) ([]byte, error) {
 	return attrs.MD5, nil
 }
 
+// Filesize returns the size in bytes of a GCS object with the given filepath.
+func (c *Client) Filesize(filepath string) (int64, error) {
+	ctx, cancel := c.createContext()
+	defer cancel()
+
+	attrs, err := c.Bucket.Object(filepath).Attrs(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	return attrs.Size, nil
+}
+
 // Get returns a reader that can be used to retrieve a file.
 func (c *Client) Get(filepath string) (io.ReadCloser, error) {
 	ctx, cancel := c.createContext()


### PR DESCRIPTION
This is required for AIMS integration for adding tracks due to certain tracks being oversized.
The validation process take a very long time from the AIMS api platform, resulting in interuption to the batch loading.
Thus, it is essential to check before making the requests