### PR TITLE
feat(data): add RangeReader to RangeService

### DIFF
--- a/data/data-service.go
+++ b/data/data-service.go
@@ -142,13 +142,18 @@ type ParallelService interface {
 	Upload(filepath string, filesize int, r io.Reader) error
 }
 
-// RangeService allows for a part of the file to be downloaded. Dictate the
-// [start, finish) of the download, and the result will be written into
-// io.WriterAt.
+// RangeService allows for a part of the file to be retrieved. Dictate the
+// [start, finish) of the range. DownloadRange pushes the range into an
+// io.WriterAt, while RangeReader returns the range as an io.Reader so that it
+// can be consumed directly (e.g., by a csv.Reader or bufio.Reader) without
+// having to invert the write.
 //
-// For example, if start=0 and finish=5, the function should return bytes 0-4.
+// For example, if start=0 and finish=5, both should provide bytes 0-4.
+//
+// The io.ReadCloser returned by RangeReader must be closed by the caller.
 type RangeService interface {
 	DownloadRange(filepath string, w io.WriterAt, start, finish int) error
+	RangeReader(filepath string, start, finish int) (io.ReadCloser, error)
 }
 
 // StreamService allows for data to be streamed. Pass in the writer which should be streamed to.

--- a/gcp/storage/client.go
+++ b/gcp/storage/client.go
@@ -525,19 +525,53 @@ func (c *Client) Stream(filepath string, w io.Writer) error {
 func (c *Client) DownloadRange(filepath string, w io.WriterAt, start, finish int) error {
 	ww := &writeAtWrap{WriterAt: w}
 
+	r, err := c.RangeReader(filepath, start, finish)
+	if err != nil {
+		return err
+	}
+	// Closing the reader also releases the context it owns.
+	defer r.Close()
+
+	if _, err := io.Copy(ww, r); err != nil {
+		return err
+	}
+	return nil
+}
+
+// RangeReader allows for a part of the file to be read. Dictate the
+// [start, finish) of the range. For example, if start=0 and finish=5, the
+// returned reader provides bytes 0...4.
+//
+// The reader is read *after* this function returns, so the context created for
+// the request cannot be cancelled here. Instead, the returned io.ReadCloser
+// owns it and cancels it on Close. The caller must therefore always close it.
+func (c *Client) RangeReader(filepath string, start, finish int) (io.ReadCloser, error) {
 	ctx, cancel := c.createContext()
-	defer cancel()
 
 	offset := int64(start)
 	length := int64(finish) - offset
 	r, err := c.Bucket.Object(filepath).NewRangeReader(ctx, offset, length)
 	if err != nil {
-		return err
+		cancel()
+		return nil, err
 	}
-	if _, err := io.Copy(ww, r); err != nil {
-		return err
-	}
-	return nil
+	return &cancelReadCloser{
+		ReadCloser: r,
+		cancel:     cancel,
+	}, nil
+}
+
+// cancelReadCloser is an io.ReadCloser tied to a cancellable context. Close
+// closes the underlying reader, then releases the context.
+type cancelReadCloser struct {
+	io.ReadCloser
+	cancel func()
+}
+
+func (r *cancelReadCloser) Close() error {
+	err := r.ReadCloser.Close()
+	r.cancel()
+	return err
 }
 
 // Objects should return an iterator for all objects in a bucket.

--- a/gcp/storage/client_test.go
+++ b/gcp/storage/client_test.go
@@ -172,6 +172,94 @@ func TestClient(t *testing.T) {
 	}
 }
 
+// sliceWriterAt is an io.WriterAt which collects everything written to it into
+// a byte slice, growing as required.
+type sliceWriterAt struct {
+	b []byte
+}
+
+func (w *sliceWriterAt) WriteAt(p []byte, off int64) (int, error) {
+	if end := int(off) + len(p); end > len(w.b) {
+		w.b = append(w.b, make([]byte, end-len(w.b))...)
+	}
+	copy(w.b[off:], p)
+	return len(p), nil
+}
+
+// TestClient_RangeReader tests that Client.RangeReader returns the [start,
+// finish) range of an object, and that the reader remains usable after the
+// function returns (i.e., that the request context has not been cancelled).
+func TestClient_RangeReader(t *testing.T) {
+	content := []byte("test file content")
+	server, err := fakestorage.NewServerWithOptions(fakestorage.Options{
+		InitialObjects: []fakestorage.Object{
+			{
+				ObjectAttrs: fakestorage.ObjectAttrs{
+					BucketName: "Test-Bucket",
+					Name:       "test-file.txt",
+				},
+				Content: content,
+			},
+		},
+		NoListener: true,
+		Host:       "127.0.0.1",
+		Port:       1337,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Stop()
+
+	client := &Client{
+		Client: server.Client(),
+
+		// A timeout ensures the returned reader owns a cancellable context.
+		Timeout: time.Minute,
+	}
+	client.Bucket = client.Client.Bucket("Test-Bucket")
+
+	tests := []struct {
+		start    int
+		finish   int
+		expected string
+	}{
+		{0, 5, "test "},
+		{5, 9, "file"},
+		{5, len(content), "file content"},
+		{0, len(content), "test file content"},
+	}
+	for _, test := range tests {
+		r, err := client.RangeReader("test-file.txt", test.start, test.finish)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := r.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if string(b) != test.expected {
+			t.Errorf("For range [%d, %d), expected %s. Got %s", test.start, test.finish, test.expected, b)
+		}
+
+		// DownloadRange is implemented on top of RangeReader, so it should
+		// provide the same bytes.
+		w := &sliceWriterAt{}
+		if err := client.DownloadRange("test-file.txt", w, test.start, test.finish); err != nil {
+			t.Fatal(err)
+		}
+		if string(w.b) != test.expected {
+			t.Errorf("For downloaded range [%d, %d), expected %s. Got %s", test.start, test.finish, test.expected, w.b)
+		}
+	}
+
+	if _, err := client.RangeReader("does-not-exist.txt", 0, 5); err != storage.ErrObjectNotExist {
+		t.Fatalf("Expecting an 'object doesn't exist' error. Got %s", err)
+	}
+}
+
 // TestChunkedUpload tests the chunked upload functionality. It ensures that Put
 // Resume work properly.
 func TestChunkedUpload(t *testing.T) {

--- a/s3/download.go
+++ b/s3/download.go
@@ -1,6 +1,7 @@
 package s3util
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 
@@ -56,6 +57,29 @@ func (s *Service) Download(filepath string, w io.WriterAt, p *data.DownloadParam
 		}
 	}
 	return s.download(filepath, w, concurrency)
+}
+
+// RangeReader allows for a part of the file to be read. Dictate the
+// [start, finish) of the range. For example, if start=0 and finish=5, the
+// returned reader provides bytes 0...4.
+func (s *Service) RangeReader(filepath string, start, finish int) (io.ReadCloser, error) {
+	// An empty range has nothing to request. S3 would reject the resulting
+	// header outright.
+	if finish <= start {
+		return io.NopCloser(bytes.NewReader(nil)), nil
+	}
+
+	// The end of the HTTP range header is inclusive, whereas finish is
+	// exclusive.
+	out, err := s.Client.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(s.Bucket),
+		Key:    aws.String(filepath),
+		Range:  aws.String(fmt.Sprintf("bytes=%d-%d", start, finish-1)),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out.Body, nil
 }
 
 func (s *Service) DownloadRange(filepath string, w io.WriterAt, start, finish int) error {


### PR DESCRIPTION
Every consumer of a byte range wants to pull it -- into a csv.Reader, a bufio.Reader, an io.Copy -- but RangeService could only push it into an io.WriterAt, so each caller had to invert it with an io.Pipe, a goroutine and an io.Writer -> io.WriterAt shim.

RangeReader(filepath, start, finish) returns the [start, finish) range as an io.ReadCloser, with semantics identical to DownloadRange.

- gcp/storage.Client: returns the object's NewRangeReader. Since the reader is consumed after the call returns, the request context cannot be cancelled on return; the returned io.ReadCloser owns the cancel func and invokes it on Close. DownloadRange is now implemented on top of RangeReader, deferring Close (which releases the context in place of its old defer cancel()).
- s3.Service: GetObject with a bytes=<start>-<finish-1> Range header, accounting for the header's end being inclusive where finish is exclusive, and returns the response body. An empty range short-circuits to an empty reader rather than sending a header S3 would reject.

Tested against the fake GCS server: ranges, parity with DownloadRange, and the object-not-found error.